### PR TITLE
チュートリアル(ベーシック・アドバンス)：Entityの表記揺れをAdminConsoleと統一

### DIFF
--- a/gettingstarted/src/docs/asciidoc/advanced/customize_en.adoc
+++ b/gettingstarted/src/docs/asciidoc/advanced/customize_en.adoc
@@ -69,7 +69,7 @@ After setting the Entity, add a Reference item again.
 !===
 |===
 
-.Today's task Entity
+.Daily task Entity
 [cols = "1,1,1,3a", options = "header"]
 |===
 | Name | DisplayName | Type | Attribute value
@@ -88,7 +88,7 @@ After setting the Entity, add a Reference item again.
 | projectAndVersion | Project Version | String |
 |===
 
-.Today's schedule Entity
+.Daily schedule Entity
 [cols = "1,1,1,3a", options = "header"]
 |===
 | Name | DisplayName | Type | Attribute value
@@ -215,7 +215,7 @@ Here, EQL is written to obtain the value of the name of the project master.
 
 When the change is complete, save the Entity.
 
-.Today's Task Entity
+.Daily Task Entity
 Similarly, change the project version setting as follows.
 
 [options = "header"]
@@ -229,7 +229,7 @@ Similarly, change the project version setting as follows.
 
 When the change is complete, save the Entity.
 
-.Today's Schedule Entity
+.Daily Schedule Entity
 Similarly, change the settings for total man-hour (planned) [h] and total man-hour (actual) [h] as follows.
 
 [options = "header"]
@@ -240,7 +240,7 @@ Similarly, change the settings for total man-hour (planned) [h] and total man-ho
 | Type | Expression
 | Result Type | Float
 | Expression | (select sum(dailyTask.planedManhour) from tutorial.advanced.dailySchedule on .this=this) +
-※ Get the total value of man-hours (planned) [h] of today's task Entity
+※ Get the total value of man-hours (planned) [h] of daily task Entity
 |===
 
 [options = "header"]
@@ -251,7 +251,7 @@ Similarly, change the settings for total man-hour (planned) [h] and total man-ho
 | Type | Expression
 | Result Type | Float
 | Expression | (select sum(dailyTask.actualManhour) from tutorial.advanced.dailySchedule on .this=this) +
-※ Get the total value of man-hours (actual) [h] of today's task Entity
+※ Get the total value of man-hours (actual) [h] of daily task Entity
 |===
 
 When the change is complete, save the Entity.
@@ -286,12 +286,12 @@ Task master entity has version Property, and version Property also has project m
 
 Here, let's use the EventListener function to set the project version Property with custom logic that is called when registering or updating an Entity.
 
-Also, set EventListener to automatically set the name Property for today's schedule entity and today's task entity.
+Also, set EventListener to automatically set the name Property for daily schedule entity and daily task entity.
 This method can also be used in scenes where you do not want the user to enter the required property name Property directly.
 
 For details of EventListener function, refer to <<../../developerguide/datamanagement/index.adoc#ref_entity_event_listener, EventListener>>.
 
-.Today's Schedule Entity
+.Daily Schedule Entity
 Add EventListener.
 By default, EventListeners are closed, so click on the tab bar to open EventListeners.
 
@@ -316,7 +316,7 @@ Click the OK button to close the dialog and save the Entity.
 
 image::images/entity_setevent.png[]
 
-.Today's Task Entity
+.Daily Task Entity
 Similarly, add the following script to EventListener.
 
 image::images/entity_eventlistener-dailytask_en.png[]
@@ -329,7 +329,7 @@ String taskName = entity.getValue("task.name");
 entity.setName(taskName);
 ----
 
-Get the value of name Property from task master entity and set the value to name property of today's task entity.
+Get the value of name Property from task master entity and set the value to name property of daily task entity.
 
 When the change has completed, save the Entity.
 
@@ -369,7 +369,7 @@ image::images/entity_view-eventlistener_en.png[]
 === Input Check Function (Validator)
 Use Validator function when you want to check input of data to be registered in Entity was following the rule.
 
-Here, Validator is assigned so that an error is displayed when a value other than 0 to 24 is entered in the man-hour (planned) [h] and man-hour (actual) [h] of today's task Entity.
+Here, Validator is assigned so that an error is displayed when a value other than 0 to 24 is entered in the man-hour (planned) [h] and man-hour (actual) [h] of daily task Entity.
 
 First, register a message when an input validation error occurs.
 Right-click Message in the Data Model, click「Create Message Category」from the context menu that appears, and create the message below.
@@ -410,7 +410,7 @@ Click the Save button to save the message.
 Next, set Validator to Property.
 
 .plannedManhour
-Perform the following settings from the on the planned Man-hour for today's task Entity.
+Perform the following settings from the on the planned Man-hour for daily task Entity.
 
 image::images/entity_planedmanhour_en.png[]
 
@@ -434,7 +434,7 @@ Set the same for the man-hour (actual) [h] and save the Entity.
 image::images/entity_actualmanhour_en.png[]
 
 
-For confirmation, add data to today's task entity.
+For confirmation, add data to daily task entity.
 Please click new registration from the search screen.
 
 image::images/entity_create-validator_en.png[]
@@ -518,8 +518,8 @@ The following methods can be employed to display the contents of Reference type 
 Here we will deal with RefCombo and NestTable.
 
 ==== NestTable
-First, set NestTable for today's schedule Entity.
-Open Detail_Layout for today's schedule Entity.
+First, set NestTable for daily schedule Entity.
+Open Detail_Layout for daily schedule Entity.
 If the layout is not loaded, press standard load to load the default layout.
 Open the the settings of task .
 
@@ -530,7 +530,7 @@ Click Edit Property Editor.
 image::images/view_property-task_en.png[]
 
 Select `NestTable` as the display type.
-In the reference type display properties, we will add the properties of today's task entity to be displayed in NestTable.
+In the reference type display properties, we will add the properties of daily task entity to be displayed in NestTable.
 
 image::images/view_referencepropertyeditor-nesttable_en.png[]
 
@@ -572,7 +572,7 @@ Please choose corresponding editor type and then click the edit button of the pr
 When you finished adding properties, save the settings.
 This completes the NestTable settings.
 
-To confirm, add data to today's schedule Entity.
+To confirm, add data to daily schedule Entity.
 
 image::images/entity_create-nesttable_en.png[]
 
@@ -652,9 +652,9 @@ This concludes the completion of the operation check.
 
 === 2-Line Display Of Detail Screen
 By default, the property information is displayed in a table format with one column on the detail screen, but the number of columns can be increased from Detail_Layout.
-Set to display part of Property data of today's schedule Entity in 2 columns.
+Set to display part of Property data of daily schedule Entity in 2 columns.
 
-Open Detail_Layout for today's schedule Entity.
+Open Detail_Layout for daily schedule Entity.
 Drag and drop `Default Section` onto Detail Views.
 
 image::images/view_detaillayout-dailyschedule2_en.png[]
@@ -679,7 +679,7 @@ Click the Save button to save the changes.
 This completes the two-column display setting.
 
 
-Please open the details screen of today's schedule Entity for confirmation.
+Please open the details screen of daily schedule Entity for confirmation.
 You can see that the total Man Hour section is displayed in two columns.
 
 image::images/view_detailview-dailyschedule_en.png[]
@@ -910,7 +910,7 @@ image::images/top_createcalendar_en.png[]
 
 Open the created calendar.
 Register the entities you want to display on the calendar.
-Here, we want to display the contents registered in today's schedule Entity in the calendar, so drag and drop today's schedule Entity from Entity Items to Target Items.
+Here, we want to display the contents registered in daily schedule Entity in the calendar, so drag and drop daily schedule Entity from Entity Items to Target Items.
 
 image::images/top_edit-calendar_en.png[]
 
@@ -1210,7 +1210,7 @@ By setting the Name value to an arrow that extends from the user task, you can c
 |===
 
 Next, make settings for starting the workflow from Detail_Layout.
-Please set DetailScreen from DetailLayout of today's schedule Entity.
+Please set DetailScreen from DetailLayout of daily schedule Entity.
 
 image::images/other_detailview_workflowsettingf_en.png[]
 
@@ -1307,7 +1307,7 @@ Set day to the filter item.
 image::images/other_aggregationfilter_en.png[]
 
 .Aggregation Table Settings
-Set EQL to search date, total man-hour (planned), total man-hour (actual) from today's schedule Entity.
+Set EQL to search date, total man-hour (planned), total man-hour (actual) from daily schedule Entity.
 
 image::images/other_aggregationgrid_en.png[]
 
@@ -1384,4 +1384,4 @@ Click the added menu to display the scene.
 image::images/other_aggregation_en.png[]
 
 The item set in the filter item is added to the filter condition.
-You can also see that the data registered in today's schedule Entity is displayed as a line graph and a aggregation table.
+You can also see that the data registered in daily schedule Entity is displayed as a line graph and a aggregation table.

--- a/gettingstarted/src/docs/asciidoc/advanced/customize_ja.adoc
+++ b/gettingstarted/src/docs/asciidoc/advanced/customize_ja.adoc
@@ -680,7 +680,7 @@ image::images/view_dragsection.png[]
 以上で2列表示の設定は完了です。
 
 
-確認のため、今日のスケジュール(tutorial.advanced.dailySchedule)の詳細画面を開いてください。
+確認のため、今日のスケジュールEntity(tutorial.advanced.dailySchedule)の詳細画面を開いてください。
 総工数セクションが2列で表示されていることが確認できます。
 
 image::images/view_detailview-dailyschedule.png[]

--- a/gettingstarted/src/docs/asciidoc/advanced/customize_ja.adoc
+++ b/gettingstarted/src/docs/asciidoc/advanced/customize_ja.adoc
@@ -1214,7 +1214,7 @@ Nameの値をユーザータスクから伸びる矢印に設定することで�
 |===
 
 続いて、ワークフローを起動するための設定をDetail_Layoutから行います。
-今日のスケジュール(tutorial.advanced.dailySchedule)のDetailLayoutからDetailFormViewの設定を行ってください。
+今日のスケジュールEntity(tutorial.advanced.dailySchedule)のDetailLayoutからDetailFormViewの設定を行ってください。
 
 image::images/other_detailview_workflowsettingf.png[]
 

--- a/gettingstarted/src/docs/asciidoc/advanced/customize_ja.adoc
+++ b/gettingstarted/src/docs/asciidoc/advanced/customize_ja.adoc
@@ -21,7 +21,7 @@ AdminConsoleから以下の名前のEntityを作成してください。
 TypeがReferenceの項目を参照する際はすでにEntityが作成されている必要があり、
 Entityを設定後、改めてReference項目を追加します。
 
-.タスクマスタEntity
+.タスクマスタEntity(tutorial.advanced.taskMaster)
 [cols="1,1,1,3a", options="header"]
 |===
 |Name|DisplayName|Type|属性値
@@ -34,7 +34,7 @@ Entityを設定後、改めてReference項目を追加します。
 |projectAndVer|プロジェクト・バージョン|String|
 |===
 
-.バージョンマスタEntity
+.バージョンマスタEntity(tutorial.advanced.versionMaster)
 [cols="1,1,1,3a", options="header"]
 |===
 |Name|DisplayName|Type|属性値
@@ -54,7 +54,7 @@ Entityを設定後、改めてReference項目を追加します。
 |projectName|プロジェクト名|String|
 |===
 
-.プロジェクトマスタ
+.プロジェクトマスタEntity(tutorial.advanced.projectMaster)
 [cols="1,1,1,3a", options="header"]
 |===
 |Name|DisplayName|Type|属性値
@@ -69,7 +69,7 @@ Entityを設定後、改めてReference項目を追加します。
 !===
 |===
 
-.今日のタスクEntity
+.今日のタスクEntity(tutorial.advanced.dailyTask)
 [cols="1,1,1,3a", options="header"]
 |===
 |Name|DisplayName|Type|属性値
@@ -88,7 +88,7 @@ Entityを設定後、改めてReference項目を追加します。
 |projectAndVersion|プロジェクト・バージョン|String|
 |===
 
-.今日のスケジュールEntity
+.今日のスケジュールEntity(tutorial.advanced.dailySchedule)
 [cols="1,1,1,3a", options="header"]
 |===
 |Name|DisplayName|Type|属性値
@@ -127,7 +127,7 @@ AutoNumber機能は、一定の文法に従って値を自動採番する機能�
 
 AutoNumberの詳細は<<../../developerguide/datamanagement/index.adoc#ref_property_autonumber, AutoNumber>>を参照してください。
 
-.プロジェクトマスタEntity
+.プロジェクトマスタEntity(tutorial.advanced.projectMaster)
 プロジェクトIDの設定画面を表示し、設定を変更します。
 
 image::images/entity_projectid.png[]
@@ -147,7 +147,7 @@ image::images/entity_projectid.png[]
 
 変更が完了したら、Entityを保存してください。
 
-.タスクマスタEntity
+.タスクマスタEntity(tutorial.advanced.taskMaster)
 同様にタスクIDの設定を以下のように変更してください。
 
 [options="header"]
@@ -196,7 +196,7 @@ EQL についての詳しい説明を知りたい方は<<../../eqlreference/inde
 
 Expression機能の詳細は<<../../developerguide/datamanagement/index.adoc#ref_property_expression, Expression>>を参照してください。
 
-.バージョンマスタEntity
+.バージョンマスタEntity(tutorial.advanced.versionMaster)
 プロジェクト名の設定を以下のように変更してください。
 
 image::images/entity_projectname.png[]
@@ -214,7 +214,7 @@ image::images/entity_projectname.png[]
 
 変更が完了したら、Entityを保存してください。
 
-.今日のタスクEntity
+.今日のタスクEntity(tutorial.advanced.dailyTask)
 同様にプロジェクト・バージョンの設定を以下のように変更してください。
 
 [options="header"]
@@ -228,7 +228,7 @@ image::images/entity_projectname.png[]
 
 変更が完了したら、Entityを保存してください。
 
-.今日のスケジュールEntity
+.今日のスケジュールEntity(tutorial.advanced.dailySchedule)
 こちらも同様に総工数（予定）[h]と総工数（実績）[h]の設定を以下のように変更してください。
 
 [options="header"]
@@ -290,7 +290,7 @@ image::images/entity_view-expression.png[]
 
 EventListener機能の詳細は<<../../developerguide/datamanagement/index.adoc#ref_entity_event_listener, EventListener>>を参照してください。
 
-.今日のスケジュールEntity
+.今日のスケジュールEntity(tutorial.advanced.dailySchedule)
 EventListenerを追加します。
 デフォルトではEventListenersは閉じているので、バーをクリックしてEventListenersを開きます。
 
@@ -315,7 +315,7 @@ OKボタンをクリックして、ダイアログを閉じ、Entityを保存し
 
 image::images/entity_setevent.png[]
 
-.今日のタスクEntity
+.今日のタスクEntity(tutorial.advanced.dailyTask)
 同様にEventListenerに下記スクリプトを追加します。
 
 image::images/entity_eventlistener-dailytask.png[]
@@ -332,7 +332,7 @@ entity.setName(taskName);
 
 変更が完了したら、Entityを保存してください。
 
-.タスクマスタEntity
+.タスクマスタEntity(tutorial.advanced.taskMaster)
 こちらも同様にEventListenerに下記スクリプトを追加します。
 
 image::images/entity_eventlistener-taskmaster.png[]
@@ -409,7 +409,7 @@ Saveボタンをクリックし、メッセージを保存します。
 次に、PropertyにValidatorの設定を行います。
 
 .工数（予定）[h]
-今日のタスクEntityの工数（予定）[h]のPropertySettingから以下の設定を行ってください。
+今日のタスクEntity(tutorial.advanced.dailyTask)の工数（予定）[h]のPropertySettingから以下の設定を行ってください。
 
 image::images/entity_planedmanhour.png[]
 
@@ -453,7 +453,7 @@ image::images/entity_error-validator.png[]
 Entityの更新履歴を記録したい場合には、AuditLog機能を用います。
 ここでは、プロジェクトマスタEntityの更新履歴を記録するよう、AuditLogの設定を行います。
 
-プロジェクトマスタEntityで `save audit log` を有効にします。
+プロジェクトマスタEntity(tutorial.advanced.projectMaster)で `save audit log` を有効にします。
 チェックを入れることで、操作ログが記録されます。
 
 image::images/entity_auditlog.png[]
@@ -520,7 +520,7 @@ GEM画面の `SearchLayout`、 `DetailLayout`  についての詳しい説明を
 
 ==== NestTable
 まずは今日のスケジュールEntityについて、NestTableの設定を行います。
-今日のスケジュールEntityのDetail_Layoutを開いてください。
+今日のスケジュールEntity(tutorial.advanced.dailySchedule)のDetail_Layoutを開いてください。
 レイアウトが読み込まれていない場合は標準ロードを押下してデフォルトレイアウトを読み込んでください。
 タスクの設定を表示します。
 
@@ -590,7 +590,7 @@ image::images/entity_view-nesttable.png[]
 NestTableでは参照先情報を入れ子構造の表形式で表示しましたが、Reference Comboでは、参照先の情報をドロップダウン形式で表示します。
 ここでは、タスクマスタEntityのデータを関連するプロジェクト名からたどって検索できるよう、Reference Comboの設定を行います。
 
-タスクマスタEntityのSearch_Layoutを開いてください。
+タスクマスタEntity(tutorial.advanced.taskMaster)のSearch_Layoutを開いてください。
 レイアウトが読み込まれていない場合は標準ロードを押下してデフォルトレイアウトを読み込んでください。
 
 image::images/view_searchlayout-taskmaster.png[]
@@ -628,7 +628,7 @@ image::images/view_refcombosetting.png[]
 
 OKボタン、保存ボタンを順に押下して、編集内容を保存してください。
 検索画面と同様に、詳細画面についても設定を行っていきます。
-タスクマスタEntityのDetail_Layoutを開いてください。
+タスクマスタEntity(tutorial.advanced.taskMaster)のDetail_Layoutを開いてください。
 
 image::images/view_detaillayout-taskmaster.png[]
 
@@ -655,7 +655,7 @@ image::images/view_detailview-taskmaster.png[]
 デフォルトでは詳細画面ではプロパティ情報が1列の表形式で表示されますが、Detail_Layoutから列数を増やすことが可能です。
 今日のスケジュールEntityのPropertyデータの一部を2列で表示するよう設定を行います。
 
-今日のスケジュールEntityのDetail_Layoutを開いてください。
+今日のスケジュールEntity(tutorial.advanced.dailySchedule)のDetail_Layoutを開いてください。
  `標準セクション` をDetail Viewsにドラッグ&ドロップします。
 
 image::images/view_detaillayout-dailyschedule2.png[]
@@ -680,7 +680,7 @@ image::images/view_dragsection.png[]
 以上で2列表示の設定は完了です。
 
 
-確認のため、今日のスケジュールEntityの詳細画面を開いてください。
+確認のため、今日のスケジュール(tutorial.advanced.dailySchedule)の詳細画面を開いてください。
 総工数セクションが2列で表示されていることが確認できます。
 
 image::images/view_detailview-dailyschedule.png[]
@@ -1214,7 +1214,7 @@ Nameの値をユーザータスクから伸びる矢印に設定することで�
 |===
 
 続いて、ワークフローを起動するための設定をDetail_Layoutから行います。
-今日のスケジュールEntityのDetailLayoutからDetailFormViewの設定を行ってください。
+今日のスケジュール(tutorial.advanced.dailySchedule)のDetailLayoutからDetailFormViewの設定を行ってください。
 
 image::images/other_detailview_workflowsettingf.png[]
 
@@ -1311,7 +1311,7 @@ day（日付）をフィルタ項目に設定します。
 image::images/other_aggregationfilter.png[]
 
 .集計表設定
-今日のスケジュールEntityから日付、総工数（予定）、総工数（実績）を検索するEQLを設定します。
+今日のスケジュールEntity(tutorial.advanced.dailySchedule)から日付、総工数（予定）、総工数（実績）を検索するEQLを設定します。
 
 image::images/other_aggregationgrid.png[]
 

--- a/gettingstarted/src/docs/asciidoc/basic/operation_en.adoc
+++ b/gettingstarted/src/docs/asciidoc/basic/operation_en.adoc
@@ -1806,7 +1806,7 @@ Once you droped the item, a dialog to set search target etc. will be displayed.
 image::images/topview_searchresultlistdialog_en.png[]
 
 Select the Entity to be searched.
-Select the `Testing Property` Entity that we created earlier.
+Select the `Properties` Entity that we created earlier.
 (If it does not exist, it can be another Entity)
 If selected, `Result` will be set to `ResultListView` and `LinkActionView` respectively.
 Since this setting is explained separately, just click the `OK` button.
@@ -1853,7 +1853,7 @@ If you look closely, only the list of `Testing Customization` does not show the 
 image::images/topview_hidelink_en.png[]
 
 This is because the layout definition of the list displayed in SearchResultList is controlled by Entity's SearchLayout setting (search result part).
-Since `ResultList View` is registered as `default` on the settings earlier, `default` definition of SearchLayout setting of `Testing Property 2` Entity (tutorial.properties.Properties2) is used.
+Since `ResultList View` is registered as `default` on the settings earlier, `default` definition of SearchLayout setting of `Properties2` Entity is used.
 
 image::images/topview_searchresultlistdialog-properties2_en.png[]
 
@@ -1878,9 +1878,9 @@ There are cases where you want to narrow down the display items for the Top scre
 This can be achieved by defining a View to be displayed on the Top screen in the Entity SearchLayout.
 
 In the previous operation, the `ResultList View` setting was `default`.
-Here, add View for Top screen to SearchLayout of Entity for `Testing Property 2` Entity and use it with `ResultList View`.
+Here, add View for Top screen to SearchLayout of Entity for `Properties2` Entity and use it with `ResultList View`.
 
-First, display the property search layout for the `Property check 2` Entity.
+First, display the property search layout for the `Properties2` Entity.
 Since the view of `default` has already been defined, let's organize the Property to copy and display this time.
 Click the `Copy` button.
 
@@ -1914,7 +1914,7 @@ When you have finished deleting, click the `Save` button in View.
 
 image::images/topview_savesearchlayout_en.png[]
 
-In the same way, add a view to the DetailLayout of the `Property Check 2` Entity.
+In the same way, add a view to the DetailLayout of the `Properties2` Entity.
 Let the view name to be added the same as SearchLayout, which is `topview`.
 
 Let's delete all sections excepet for the basic section at the top.
@@ -1940,7 +1940,7 @@ If you click the `Detail` link here, the View definition of `topview` defibed in
 image::images/topview_detailtoolbar_en.png[]
 
 Next, use the settings of `Detail Action View` to change the View displayed in the `Detail` link (or `Edit` link) on the list.
-`Check Property 2` Open Entity DetailLayout.
+`Properties2` Open Entity DetailLayout.
 
 image::images/topview_entitycontextmenu-detaillayout_en.png[]
 
@@ -2010,7 +2010,7 @@ View definition (DetailLayout) of `topview2` specified in `Detail Action View` i
 image::images/topview_detaillayout-topview2_en.png[]
 
 Next, use the settings of `Link Action View` to change the View displayed in the `Search` button  on the list.
-`Check Property 2` Open Entity SearchLayout.
+`Properties2` Open Entity SearchLayout.
 
 image::images/topview_entitycontextmenu-searchlayout_en.png[]
 

--- a/gettingstarted/src/docs/asciidoc/basic/operation_en.adoc
+++ b/gettingstarted/src/docs/asciidoc/basic/operation_en.adoc
@@ -1837,7 +1837,7 @@ image::images/topview_dropseparator_en.png[]
 `Separator` has no setting items, so there is no edit button.
 
 Drop two of the `SearchResult List` used earlier on this` Separator`.
-On the left side, specify `Product` Entity (tutorial.product.Product), and on the right side, specify `Property confirmation 2` (tutorial.properties.Properties2).
+On the left side, specify `Product` Entity, and on the right side, specify `Properties2` Entity.
 
 image::images/topview_droptwosearchresultlist_en.png[]
 

--- a/gettingstarted/src/docs/asciidoc/basic/operation_ja.adoc
+++ b/gettingstarted/src/docs/asciidoc/basic/operation_ja.adoc
@@ -1834,7 +1834,7 @@ image::images/topview_dropseparator.png[]
 `Separator` には設定項目は無いので編集ボタンがありません。
 
 この `Separator` の上に先ほど利用した `SearchResult List` を２つドロップします。
-左側を `商品` Entity（tutorial.product.Product）、右側を`プロパティ確認用２` Entity（tutorial.properties.Properties2）と指定してください。
+左側を `商品` Entity（tutorial.product.Product）、右側を `プロパティ確認用２` Entity（tutorial.properties.Properties2）と指定してください。
 
 image::images/topview_droptwosearchresultlist.png[]
 

--- a/gettingstarted/src/docs/asciidoc/basic/operation_ja.adoc
+++ b/gettingstarted/src/docs/asciidoc/basic/operation_ja.adoc
@@ -1834,7 +1834,7 @@ image::images/topview_dropseparator.png[]
 `Separator` には設定項目は無いので編集ボタンがありません。
 
 この `Separator` の上に先ほど利用した `SearchResult List` を２つドロップします。
-左側を `商品` Entity（tutorial.product.Product）、右側を `プロパティ確認用２`Entity （tutorial.properties.Properties2）と指定してください。
+左側を `商品` Entity（tutorial.product.Product）、右側を`プロパティ確認用２` Entity（tutorial.properties.Properties2）と指定してください。
 
 image::images/topview_droptwosearchresultlist.png[]
 

--- a/gettingstarted/src/docs/asciidoc/basic/operation_ja.adoc
+++ b/gettingstarted/src/docs/asciidoc/basic/operation_ja.adoc
@@ -125,7 +125,7 @@ EntityのNameに対して `.` （ドット）を使用すると、階層を表�
 
 ===== Propertyの新規作成
 作成したEntityに対してPropertyを追加していきます。
-今回は商品Entityから参照されている商品カテゴリEntityを先に編集します。
+今回は商品Entity(tutorial.product.Product)から参照されている商品カテゴリEntity(tutorial.product.ProductCategory)を先に編集します。
 
 ////
 階層が足りない、=6個(h6)で暫定対応
@@ -200,7 +200,7 @@ image::images/createentity_saveproductcategory.png[]
 階層が足りない、=6個(h6)で暫定対応
 ////
 ====== 商品Entityの定義
-商品Entityですが、こちらの `商品コード` 、 `商品名` についても商品カテゴリEntityと同様に `oid` と `name` を利用することとします。
+商品Entity(tutorial.product.Product)ですが、こちらの `商品コード` 、 `商品名` についても商品カテゴリEntity(tutorial.product.ProductCategory)と同様に `oid` と `name` を利用することとします。
 残りの属性となる `価格` と `商品カテゴリ` への参照用Propertyを追加します。
 商品カテゴリEntityと同様に `Add` ボタンから追加します。
 
@@ -1834,7 +1834,7 @@ image::images/topview_dropseparator.png[]
 `Separator` には設定項目は無いので編集ボタンがありません。
 
 この `Separator` の上に先ほど利用した `SearchResult List` を２つドロップします。
-左側を `商品` Entity（tutorial.product.Product）、右側を `プロパティ確認用２` （tutorial.properties.Properties2）と指定してください。
+左側を `商品` Entity（tutorial.product.Product）、右側を `プロパティ確認用２`Entity （tutorial.properties.Properties2）と指定してください。
 
 image::images/topview_droptwosearchresultlist.png[]
 
@@ -1877,7 +1877,7 @@ image::images/topview_searchresult-dialog.png[]
 先ほどの操作では `ResultList View` の設定は `default` となっていました。
 ここでは `プロパティ確認用２` EntityのSearchLayoutに対してTop画面用のViewを追加して、それを `ResultList View` で利用してみます。
 
-まずは `プロパティ確認用２` EntityのSearchLayoutを表示します。
+まずは `プロパティ確認用２` Entity（tutorial.properties.Properties2）のSearchLayoutを表示します。
 既に `default` のViewは定義してありますので、今回はこれをコピーして表示するPropertyを整理しましょう。
 `コピー` ボタンをクリックしてください。
 
@@ -1937,7 +1937,7 @@ image::images/topview_searchresultlist-topview.png[]
 image::images/topview_detailtoolbar.png[]
 
 続いて、 `Detail Action View` の設定を利用して、一覧上の `詳細` リンク（または `編集` リンク）で表示されるViewを変更してみます。
-`プロパティ確認用２` EntityのDetailLayoutを開いてください。
+`プロパティ確認用２` Entity（tutorial.properties.Properties2）のDetailLayoutを開いてください。
 
 image::images/topview_entitycontextmenu-detaillayout.png[]
 
@@ -2007,7 +2007,7 @@ image::images/topview_searchresultlist-topview.png[]
 image::images/topview_detaillayout-topview2.png[]
 
 次に `Link Action View` の設定を利用して、一覧内の `検索結果を表示する` ボタンを押下した際に表示されるViewを変更してみます。
-`プロパティ確認用２` EntityのSearchLayoutを開いてください。
+`プロパティ確認用２` Entity（tutorial.properties.Properties2）のSearchLayoutを開いてください。
 
 image::images/topview_entitycontextmenu-searchlayout.png[]
 
@@ -2166,7 +2166,7 @@ image::images/entitymenu_searchlayout-topview2.png[]
 それぞれの画面にアイコンを設定してみましょう。
 
 ==== メニュー
-`Menu` の `DEFAULT` 設定を開き、 `商品` Entityの設定画面を開いてください。
+`Menu` の `DEFAULT` 設定を開き、 `商品` Entity(tutorial.product.Product)の設定画面を開いてください。
 `Icon Tag` の項目があるので、ここにhtmlタグを設定します。
 
 image::images/icon_menu_setting.png[]
@@ -2190,7 +2190,7 @@ image::images/icon_top.png[]
 Top画面のお知らせ情報にアイコンが表示されました。
 
 ==== 検索画面
-`商品` Entityの `SearchLayout` を開き、検索画面の設定画面を開いてください。
+`商品` Entity(tutorial.product.Product)の `SearchLayout` を開き、検索画面の設定画面を開いてください。
 `アイコンタグ` の項目があるので、ここにhtmlタグを設定します。
 
 image::images/icon_searchlayout_setting.png[]
@@ -2202,7 +2202,7 @@ image::images/icon_searchlayout.png[]
 `商品` Entityの検索画面にアイコンが表示されました。
 
 ==== 詳細画面
-`商品` Entityの `DetailLayout` を開き、詳細画面の設定画面を開いてください。
+`商品` Entity(tutorial.product.Product)の `DetailLayout` を開き、詳細画面の設定画面を開いてください。
 `アイコンタグ` の項目があるので、ここにhtmlタグを設定します。
 
 image::images/icon_detaillayout_setting.png[]


### PR DESCRIPTION
**概要**
チュートリアル(ベーシック、アドバンス)で発生していたEntity名の表記揺れを統一
