### PR TITLE
Workflow: Task Queue Select ConditionがPreparedQueryとして解釈される点を追記

### DIFF
--- a/developerguide/src/docs/asciidoc/materialdesigncomponents/topview/setting.adoc
+++ b/developerguide/src/docs/asciidoc/materialdesigncomponents/topview/setting.adoc
@@ -334,6 +334,7 @@ Custom Title::
 
 |Task Queue Select Condition
 | `全てのタスク` に表示するキューを取得する際の条件を指定します。
+指定した条件値はPreparedQuery（GroovyTemplate）として処理されます。
 条件を指定した場合、 `全てのタスク` にはタスク一覧で指定したキューか、未指定の場合には選択可能なキューに紐づくタスクのみ表示します。
 
 |Display tasks whose taskQueues is null.

--- a/developerguide/src/docs/asciidoc/workflow/setting.adoc
+++ b/developerguide/src/docs/asciidoc/workflow/setting.adoc
@@ -1573,6 +1573,7 @@ Custom Title ::
 
 |Task Queue Select Condition
 | `全てのタスク` に表示するキューを取得する際の条件を指定します。
+指定した条件値はPreparedQuery（GroovyTemplate）として処理されます。
 条件を指定した場合、 `全てのタスク` にはタスク一覧で指定したキューか、未指定の場合には選択可能なキューに紐づくタスクのみ表示します。
 
 |Display tasks whoes taskQueues is null.

--- a/developerguide/src/docs/asciidoc/workflow/setting.adoc
+++ b/developerguide/src/docs/asciidoc/workflow/setting.adoc
@@ -1576,7 +1576,7 @@ Custom Title ::
 指定した条件値はPreparedQuery（GroovyTemplate）として処理されます。
 条件を指定した場合、 `全てのタスク` にはタスク一覧で指定したキューか、未指定の場合には選択可能なキューに紐づくタスクのみ表示します。
 
-|Display tasks whoes taskQueues is null.
+|Display tasks whose taskQueues is null.
 |キューの取得条件を指定した場合に、キューに紐づかないタスクを取得するかを指定します。
 チェックした場合、キューが未指定のタスクも取得します。
 


### PR DESCRIPTION
ワークフロー機能のタスク一覧パーツにおける [Task Queue Select Condition](https://iplass.org/docs/developerguide/workflow/index.html#:~:text=Task%20Queue%20Select%20Condition) が、検索時にPreparedQueryとして解釈されることを追記する。