### PR TITLE
GEM : Csv*→File*にリネームしたプロパティの後方互換復活対応 （ドキュメント）（4.0）

### DIFF
--- a/serviceconfig/src/docs/asciidoc/gem/gemconfigservice_en.adoc
+++ b/serviceconfig/src/docs/asciidoc/gem/gemconfigservice_en.adoc
@@ -115,25 +115,81 @@ Please configure these items along with the settings from community editions.
 [cols="1,1,3", options="header"]
 |===
 | Item | Value | Description
+| savedListCsvDownloadInterval | int a|
+WARNING: This config item is not recommended. This setting flag will be deleted in a future version. Please use the savedListFileDownloadInterval instead.
+
+Set the file download interval of the SavedList list overviews to prevent redundant download requests. If 0 is set, the interval will be infinite. The default value is 60000 (1 minute).
 | savedListFileDownloadInterval | int | Set the file download interval of the SavedList list overviews to prevent redundant download requests. If 0 is set, the interval will be infinite. The default value is 60000 (1 minute).
 | savedListFileSupportType | SavedListFileSupportType | The file format for downloading SavedList can be specified as CSV, EXCEL, or SPECIFY. The default value is CSV.
 | entitylistingSearchInterval | int | EntityListing search  interval to prevent redundant search requests. If 0 is set, it will be infinite. The default value is 60000 (1 minute).
+| entitylistingCsvDownloadInterval | int a|
+WARNING: This config item is not recommended. This setting flag will be deleted in a future version. Please use the entitylistingFileDownloadInterval instead.
+
+EntityListing file download interval to prevent redundant download requests. If 0 is set, it will be infinite. The default value is 60000 (1 minute).
 | entitylistingFileDownloadInterval | int | EntityListing file download interval to prevent redundant download requests. If 0 is set, it will be infinite. The default value is 60000 (1 minute).
 | entityListingFileSupportType | EntityListingFileSupportType | The file format for downloading EntityListing can be specified as CSV, EXCEL, or SPECIFY. The default value is CSV.
+| aggregationCsvDownloadInterval | int a|
+WARNING: This config item is not recommended. This setting flag will be deleted in a future version. Please use the aggregationFileDownloadInterval instead.
+
+Aggregation file download interval. If 0 is set, it will be indefinite. The default value is 60000 (1 minute).
 | aggregationFileDownloadInterval | int | Aggregation file download interval. If 0 is set, it will be indefinite. The default value is 60000 (1 minute).
+| aggregationRawdataCsvDownloadInterval | int a|
+WARNING: This config item is not recommended. This setting flag will be deleted in a future version. Please use the aggregationRawdataFileDownloadInterval instead.
+
+Aggregation raw data file download interval. If 0 is set, it will be infinite. The default value is 60000 (1 minute).
 | aggregationRawdataFileDownloadInterval | int | Aggregation raw data file download interval. If 0 is set, it will be infinite. The default value is 60000 (1 minute).
 | aggregationFileSupportType | AggregationFileSupportType | The file format for downloading aggregation can be specified as CSV, EXCEL, or SPECIFY. The default value is CSV.
 | aggregationRawdataFileSupportType | AggregationFileSupportType | The file format for downloading raw data for aggregation can be specified as CSV, EXCEL, or SPECIFY. The default value is CSV.
+| showBothAggregationCsvDownloadButton | boolean a|
+WARNING: This config item is not recommended. This setting flag will be deleted in a future version. Please use the showBothAggregationFileDownloadButton instead.
+
+Whether to display the Aggregation file download button both above and below the summary table. The default value is false.
 | showBothAggregationFileDownloadButton | boolean | Whether to display the Aggregation file download button both above and below the summary table. The default value is false.
+| dividingTableSideAtCrosstabCsvDownload | boolean a|
+WARNING: This config item is not recommended. This setting flag will be deleted in a future version. Please use the dividingTableSideAtCrosstabFileDownload instead.
+
+Whether to divide and output the table side by file download of Aggregation (Crosstab). The default value is false.
 | dividingTableSideAtCrosstabFileDownload | boolean | Whether to divide and output the table side by file download of Aggregation (Crosstab). The default value is false.
+| dividingTableHeadAtCrosstabCsvDownload | boolean a|
+WARNING: This config item is not recommended. This setting flag will be deleted in a future version. Please use the dividingTableHeadAtCrosstabFileDownload instead.
+
+Whether to output by dividing the header of the table with file download of Aggregation (Crosstab). The default value is false.
 | dividingTableHeadAtCrosstabFileDownload | boolean | Whether to output by dividing the header of the table with file download of Aggregation (Crosstab). The default value is false.
+| outputItemLabelCrosstabCsvDownload | boolean a|
+WARNING: This config item is not recommended. This setting flag will be deleted in a future version. Please use the outputItemLabelCrosstabFileDownload instead.
+
+Whether to display header/table-side item names in file download of Aggregation (Crosstab). The default value is false.
 | outputItemLabelCrosstabFileDownload | boolean | Whether to display header/table-side item names in file download of Aggregation (Crosstab). The default value is false.
 | entitylistingSearchLimit | int | EntityListing's search limit. The default value is 10.
+| entitylistingCsvDownloadWithFooter | boolean a|
+WARNING: This config item is not recommended. This setting flag will be deleted in a future version. Please use the entitylistingFileDownloadWithFooter instead.
+
+Set whether to output footer in file download of EntityListing. The default value is false.
 | entitylistingFileDownloadWithFooter | boolean | Set whether to output footer in file download of EntityListing. The default value is false.
+| entitylistingCsvDownloadFooter | String a|
+WARNING: This config item is not recommended. This setting flag will be deleted in a future version. Please use the entitylistingFileDownloadFooter instead.
+
+Footer wording for file of EntityListing.
 | entitylistingFileDownloadFooter | String | Footer wording for file of EntityListing.
+| aggregationCsvDownloadWithFooter | boolean a|
+WARNING: This config item is not recommended. This setting flag will be deleted in a future version. Please use the aggregationFileDownloadWithFooter instead.
+
+Whether to output a footer for aggregate file downloads. The default value is false.
 | aggregationFileDownloadWithFooter | boolean | Whether to output a footer for aggregate file downloads. The default value is false.
+| aggregationCsvDownloadFooter | String a|
+WARNING: This config item is not recommended. This setting flag will be deleted in a future version. Please use the aggregationFileDownloadFooter instead.
+
+footer wording of the aggregate file downloads.
 | aggregationFileDownloadFooter | String | footer wording of the aggregate file downloads.
+| aggregationRawdataCsvDownloadWithFooter | boolean a|
+WARNING: This config item is not recommended. This setting flag will be deleted in a future version. Please use the aggregationRawdataFileDownloadWithFooter instead.
+
+Whether to output a footer when downloading raw file data for aggregation. The default value is false.
 | aggregationRawdataFileDownloadWithFooter | boolean | Whether to output a footer when downloading raw file data for aggregation. The default value is false.
+| aggregationRawdataCsvDownloadFooter | String a|
+WARNING: This config item is not recommended. This setting flag will be deleted in a future version. Please use the aggregationRawdataFileDownloadFooter instead.
+
+Footer wording of raw data aggregate file downloads.
 | aggregationRawdataFileDownloadFooter | String | Footer wording of raw data aggregate file downloads.
 | confirmUserTaskSubmit | boolean | Whether to display the task confirmation dialog on the workflow task edit screen. The default value is true.
 | confirmUserTaskCancel | boolean | Whether to display a cancellation confirmation dialog on the workflow task edit screen. The default value is true.

--- a/serviceconfig/src/docs/asciidoc/gem/gemconfigservice_ja.adoc
+++ b/serviceconfig/src/docs/asciidoc/gem/gemconfigservice_ja.adoc
@@ -112,25 +112,81 @@ CAUTION: 後方互換性のための設定フラグです。将来のバージ�
 [cols="1,1,3", options="header"]
 |===
 | 項目 | 値 | 説明
+| savedListCsvDownloadInterval | int a| 
+WARNING: 本設定項目は非推奨となります。将来のバージョンでは本設定項目は削除されます。savedListFileDownloadIntervalを利用ください。
+
+SavedList一覧のファイルダウンロードのインターバル。0を設定した場合は無期限となります。デフォルト値は60000（1分）です。
 | savedListFileDownloadInterval | int | SavedList一覧のファイルダウンロードのインターバル。0を設定した場合は無期限となります。デフォルト値は60000（1分）です。
 | savedListFileSupportType | SavedListFileSupportType | SavedList一覧のファイルダウンロードで利用するファイル形式。`CSV` `EXCEL` `SPECIFY` から指定します。デフォルト値は `CSV` です。
 | entitylistingSearchInterval | int | EntityListingの検索処理のインターバル。0を設定した場合は無期限となります。デフォルト値は60000（1分）です。
+| entitylistingCsvDownloadInterval | int a| 
+WARNING: 本設定項目は非推奨となります。将来のバージョンでは本設定項目は削除されます。entitylistingFileDownloadIntervalを利用ください。
+
+EntityListingのファイルダウンロードのインターバル。0を設定した場合は無期限となります。デフォルト値は60000（1分）です。
 | entitylistingFileDownloadInterval | int | EntityListingのファイルダウンロードのインターバル。0を設定した場合は無期限となります。デフォルト値は60000（1分）です。
 | entityListingFileSupportType | EntityListingFileSupportType | EntityListingのファイルダウンロードで利用するファイル形式。`CSV` `EXCEL` `SPECIFY` から指定します。デフォルト値は `CSV` です。
+| aggregationCsvDownloadInterval | int a| 
+WARNING: 本設定項目は非推奨となります。将来のバージョンでは本設定項目は削除されます。aggregationFileDownloadIntervalを利用ください。
+
+Aggregationのファイルダウンロードのインターバル。0を設定した場合は無期限となります。デフォルト値は60000（1分）です。
 | aggregationFileDownloadInterval | int | Aggregationのファイルダウンロードのインターバル。0を設定した場合は無期限となります。デフォルト値は60000（1分）です。
+| aggregationRawdataCsvDownloadInterval | int a| 
+WARNING: 本設定項目は非推奨となります。将来のバージョンでは本設定項目は削除されます。aggregationRawdataFileDownloadIntervalを利用ください。
+
+Aggregationのローデータファイルダウンロードのインターバル。0を設定した場合は無期限となります。デフォルト値は60000（1分）です。
 | aggregationRawdataFileDownloadInterval | int | Aggregationのローデータファイルダウンロードのインターバル。0を設定した場合は無期限となります。デフォルト値は60000（1分）です。
 | aggregationFileSupportType | AggregationFileSupportType | Aggregationのファイルダウンロードで利用するファイル形式。`CSV` `EXCEL` `SPECIFY` から指定します。デフォルト値は `CSV` です。
 | aggregationRawdataFileSupportType | AggregationFileSupportType | Aggregationのローデータファイルダウンロードで利用するファイル形式。`CSV` `EXCEL` `SPECIFY` から指定します。デフォルト値は `CSV` です。
+| showBothAggregationCsvDownloadButton | boolean a| 
+WARNING: 本設定項目は非推奨となります。将来のバージョンでは本設定項目は削除されます。showBothAggregationFileDownloadButtonを利用ください。
+
+Aggregationのファイルダウンロードを集計表の上下に表示するか。デフォルト値はfalseです。
 | showBothAggregationFileDownloadButton | boolean | Aggregationのファイルダウンロードを集計表の上下に表示するか。デフォルト値はfalseです。
+| dividingTableSideAtCrosstabCsvDownload | boolean a| 
+WARNING: 本設定項目は非推奨となります。将来のバージョンでは本設定項目は削除されます。dividingTableSideAtCrosstabFileDownloadを利用ください。
+
+Aggregation(Crosstab)のファイルダウンロードで表側を分割して出力するか。デフォルト値はfalseです。
 | dividingTableSideAtCrosstabFileDownload | boolean | Aggregation(Crosstab)のファイルダウンロードで表側を分割して出力するか。デフォルト値はfalseです。
+| dividingTableHeadAtCrosstabCsvDownload | boolean a| 
+WARNING: 本設定項目は非推奨となります。将来のバージョンでは本設定項目は削除されます。dividingTableHeadAtCrosstabFileDownloadを利用ください。
+
+Aggregation(Crosstab)のファイルダウンロードで表頭を分割して出力するか。デフォルト値はfalseです。
 | dividingTableHeadAtCrosstabFileDownload | boolean | Aggregation(Crosstab)のファイルダウンロードで表頭を分割して出力するか。デフォルト値はfalseです。
+| outputItemLabelCrosstabCsvDownload | boolean a| 
+WARNING: 本設定項目は非推奨となります。将来のバージョンでは本設定項目は削除されます。outputItemLabelCrosstabFileDownloadを利用ください。
+
+Aggregation(Crosstab)のファイルダウンロードで表頭/表側のアイテム名を表示するか。デフォルト値はfalseです。
 | outputItemLabelCrosstabFileDownload | boolean | Aggregation(Crosstab)のファイルダウンロードで表頭/表側のアイテム名を表示するか。デフォルト値はfalseです。
 | entitylistingSearchLimit | int | EntityListingの検索Limit。デフォルト値は10です。
+| entitylistingCsvDownloadWithFooter | boolean a| 
+WARNING: 本設定項目は非推奨となります。将来のバージョンでは本設定項目は削除されます。entitylistingFileDownloadWithFooterを利用ください。
+
+EntityListingのファイルダウンロードでフッターを出力するか。デフォルト値はfalseです。
 | entitylistingFileDownloadWithFooter | boolean | EntityListingのファイルダウンロードでフッターを出力するか。デフォルト値はfalseです。
+| entitylistingCsvDownloadFooter | String a| 
+WARNING: 本設定項目は非推奨となります。将来のバージョンでは本設定項目は削除されます。entitylistingFileDownloadFooterを利用ください。
+
+EntityListingのファイルダウンロードのフッター文言。
 | entitylistingFileDownloadFooter | String | EntityListingのファイルダウンロードのフッター文言。
+| aggregationCsvDownloadWithFooter | boolean a| 
+WARNING: 本設定項目は非推奨となります。将来のバージョンでは本設定項目は削除されます。aggregationFileDownloadWithFooterを利用ください。
+
+集計のファイルダウンロードでフッターを出力するか。デフォルト値はfalseです。
 | aggregationFileDownloadWithFooter | boolean | 集計のファイルダウンロードでフッターを出力するか。デフォルト値はfalseです。
+| aggregationCsvDownloadFooter | String a| 
+WARNING: 本設定項目は非推奨となります。将来のバージョンでは本設定項目は削除されます。aggregationFileDownloadFooterを利用ください。
+
+集計のファイルダウンロードのフッター文言。
 | aggregationFileDownloadFooter | String | 集計のファイルダウンロードのフッター文言。
+| aggregationRawdataCsvDownloadWithFooter | boolean a| 
+WARNING: 本設定項目は非推奨となります。将来のバージョンでは本設定項目は削除されます。aggregationRawdataFileDownloadWithFooterを利用ください。
+
+集計のローデータファイルダウンロードでフッターを出力するか。デフォルト値はfalseです。
 | aggregationRawdataFileDownloadWithFooter | boolean | 集計のローデータファイルダウンロードでフッターを出力するか。デフォルト値はfalseです。
+| aggregationRawdataCsvDownloadFooter | String a| 
+WARNING: 本設定項目は非推奨となります。将来のバージョンでは本設定項目は削除されます。aggregationRawdataFileDownloadFooterを利用ください。
+
+集計のローデータのファイルダウンロードのフッター文言。
 | aggregationRawdataFileDownloadFooter| String | 集計のローデータのファイルダウンロードのフッター文言。
 | confirmUserTaskSubmit| boolean | ワークフローのタスク編集画面でタスク確認ダイアログを表示するか。デフォルト値はfalseです。
 | confirmUserTaskCancel| boolean | ワークフローのタスク編集画面でキャンセル確認ダイアログを表示するか。デフォルト値はfalseです。


### PR DESCRIPTION
backport of #91 